### PR TITLE
Fix permissions error for Grafana >=5.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
   grafana:
     image: grafana/grafana
-    user: '104'
+    user: 'root'
     ports:
       - "3000:3000"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3"
 services:
   grafana:
     image: grafana/grafana
+    user: '104'
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
I was getting this error in the Grafana container:
```
GF_PATHS_CONFIG='/etc/grafana/grafana.ini' is not readable.
You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later
t=2021-11-18T08:11:55+0000 lvl=crit msg="failed to parse \"/etc/grafana/grafana.ini\": open /etc/grafana/grafana.ini: permission denied"
```
This PR implements [the solution described by Grafana](https://grafana.com/docs/grafana/latest/installation/docker/#specify-a-user-in-docker-composeyml).